### PR TITLE
Add PositionProperties to device conversion examples

### DIFF
--- a/src/to-geojson/device-position-converter.ts
+++ b/src/to-geojson/device-position-converter.ts
@@ -17,8 +17,7 @@ import { FeatureCollection, Point } from "geojson";
  *    with features corresponding to the entries in the response.
  *
  * `DeviceId` will be mapped to the `id` of the output Feature. Fields other than `Position` and `DeviceId` of the
- * device position will be mapped into the properties of the corresponding Feature. Items inside the
- * `PositionProperties` field will also be mapped into the properties of the corresponding Feature.
+ * device position will be mapped into the properties of the corresponding Feature.
  *
  * Any device position without the Position field will be skipped.
  *


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
This change adds examples of how a tracker device's PositionProperties are converted to a FeatureCollection's properties.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
