### PR TITLE
route-converter change

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,18 @@ const featureCollection = placeToFeatureCollection(response, {
 
 Converts a [route](https://docs.aws.amazon.com/location/latest/developerguide/route-concepts.html) to a GeoJSON FeatureCollection with a single MultiLineString Feature. Each LineString entry of the MultiLineString represents a leg of the route.
 
+The flattenProperties option will flatten the JSON response in properties.This option is mainly used when retrieving "MapLibre GL JS" attributes.
+
 ```javascript
 const response = { ... };
 const featureCollection = routeToFeatureCollection(response)
+```
+
+```javascript
+const response = { ... };
+const featureCollection = placeToFeatureCollection(response, {
+    flattenProperties: true
+});
 ```
 
 ## Error Handling

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/amazon-location-utilities-datatypes",
   "description": "Amazon Location Utilities - Data Types for JavaScript",
   "license": "Apache-2.0",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "keywords": [],
   "author": {
     "name": "Amazon Web Services",

--- a/src/to-geojson/place-converter.ts
+++ b/src/to-geojson/place-converter.ts
@@ -9,7 +9,7 @@ import {
   SearchPlaceIndexForPositionResponse,
   SearchPlaceIndexForTextResponse,
 } from "@aws-sdk/client-location";
-import { emptyFeatureCollection, toFeatureCollection } from "./utils";
+import { emptyFeatureCollection, toFeatureCollection, flattenProperties } from "./utils";
 
 /**
  * It converts place responses to a FeatureCollection with Point Features. It converts
@@ -342,23 +342,4 @@ function convertPlaceToFeature(
     return feature;
   }
   return null;
-}
-
-/**
- * Optionally flatten the Amazon Location Place object.
- *
- * @param obj Amazon Location Place object.
- * @returns Flattened objects.
- */
-function flattenProperties(obj: Record<string, unknown>, prefix = ""): Record<string, unknown> {
-  return Object.keys(obj).reduce((acc: Record<string, unknown>, key: string) => {
-    const newKey = prefix ? `${prefix}.${key}` : key;
-    const value = obj[key];
-    if (value && typeof value === "object" && key !== "Geometry") {
-      Object.assign(acc, flattenProperties(value as Record<string, unknown>, newKey));
-    } else {
-      acc[newKey] = value;
-    }
-    return acc;
-  }, {});
 }

--- a/src/to-geojson/route-converter.test.ts
+++ b/src/to-geojson/route-converter.test.ts
@@ -7,7 +7,7 @@ import { FeatureCollection } from "geojson";
 import { emptyFeatureCollection } from "./utils";
 
 describe("routeToFeatureCollection", () => {
-  it("should convert CalculateRouteResponse to a FeatureCollection", () => {
+  it("should convert CalculateRouteResponse to a FeatureCollection and nested properties when flattenProperties is false or undefined", () => {
     const input: CalculateRouteResponse = {
       Legs: [
         {
@@ -82,6 +82,79 @@ describe("routeToFeatureCollection", () => {
     expect(routeToFeatureCollection(input)).toEqual(output);
   });
 
+  it("should convert CalculateRouteResponse to a FeatureCollection with a single feature and flattened properties when flattenProperties is true", () => {
+    const input: CalculateRouteResponse = {
+      Legs: [
+        {
+          Distance: 0.05,
+          DurationSeconds: 10.88,
+          EndPosition: [123.0, 12.0],
+          Geometry: {
+            LineString: [
+              [123.0, 11.0],
+              [123.5, 11.5],
+              [123.0, 12.0],
+            ],
+          },
+          StartPosition: [123.0, 11.0],
+          Steps: [],
+        },
+        {
+          Distance: 0.05,
+          DurationSeconds: 9.4,
+          EndPosition: [123.0, 14.0],
+          Geometry: {
+            LineString: [
+              [123.0, 12.0],
+              [123.5, 13.5],
+              [123.0, 14.0],
+            ],
+          },
+          StartPosition: [123.0, 12.0],
+          Steps: [],
+        },
+      ],
+      Summary: {
+        DataSource: "Esri",
+        Distance: 1,
+        DistanceUnit: "Kilometers",
+        DurationSeconds: 30,
+        RouteBBox: [-123.149, 49.289, -123.141, 49.287],
+      },
+    };
+    const output: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          bbox: [-123.149, 49.289, -123.141, 49.287],
+          properties: {
+            DataSource: "Esri",
+            Distance: 1,
+            DistanceUnit: "Kilometers",
+            DurationSeconds: 30,
+          },
+          geometry: {
+            type: "MultiLineString",
+            coordinates: [
+              [
+                [123.0, 11.0],
+                [123.5, 11.5],
+                [123.0, 12.0],
+              ],
+              [
+                [123.0, 12.0],
+                [123.5, 13.5],
+                [123.0, 14.0],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+    expect(routeToFeatureCollection(input, { flattenProperties: true })).toEqual(output);
+  });
+
   it("should convert CalculateRouteResponse without Summary", () => {
     const input: CalculateRouteResponse = {
       Legs: [
@@ -143,7 +216,7 @@ describe("routeToFeatureCollection", () => {
     expect(routeToFeatureCollection(input)).toEqual(output);
   });
 
-  it("should convert CalculateRouteResponse to a FeatureCollection a leg missing the Geometry field", () => {
+  it("should convert CalculateRouteResponse to a FeatureCollection a leg missing the Geometry field with a single feature and nested properties when flattenProperties is false or undefined", () => {
     const input: CalculateRouteResponse = {
       Legs: [
         {
@@ -223,6 +296,86 @@ describe("routeToFeatureCollection", () => {
       ],
     };
     expect(routeToFeatureCollection(input)).toEqual(output);
+  });
+
+  it("should convert CalculateRouteResponse to a FeatureCollection a leg missing the Geometry field with a single feature and flattened properties when flattenProperties is true", () => {
+    const input: CalculateRouteResponse = {
+      Legs: [
+        {
+          Distance: 0.05,
+          DurationSeconds: 10.88,
+          EndPosition: [123.0, 12.0],
+          Geometry: {
+            LineString: [
+              [123.0, 11.0],
+              [123.5, 11.5],
+              [123.0, 12.0],
+            ],
+          },
+          StartPosition: [123.0, 11.0],
+          Steps: [],
+        },
+        {
+          Distance: 0.05,
+          DurationSeconds: 10.7,
+          EndPosition: [123.0, 13.0],
+          StartPosition: [123.0, 12.0],
+          Steps: [],
+        },
+        {
+          Distance: 0.05,
+          DurationSeconds: 9.4,
+          EndPosition: [123.0, 14.0],
+          Geometry: {
+            LineString: [
+              [123.0, 13.0],
+              [123.5, 13.5],
+              [123.0, 14.0],
+            ],
+          },
+          StartPosition: [123.0, 13.0],
+          Steps: [],
+        },
+      ],
+      Summary: {
+        DataSource: "Esri",
+        Distance: 1,
+        DistanceUnit: "Kilometers",
+        DurationSeconds: 30,
+        RouteBBox: [-123.149, 49.289, -123.141, 49.287],
+      },
+    };
+    const output: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          bbox: [-123.149, 49.289, -123.141, 49.287],
+          properties: {
+            DataSource: "Esri",
+            Distance: 1,
+            DistanceUnit: "Kilometers",
+            DurationSeconds: 30,
+          },
+          geometry: {
+            type: "MultiLineString",
+            coordinates: [
+              [
+                [123.0, 11.0],
+                [123.5, 11.5],
+                [123.0, 12.0],
+              ],
+              [
+                [123.0, 13.0],
+                [123.5, 13.5],
+                [123.0, 14.0],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+    expect(routeToFeatureCollection(input, { flattenProperties: true })).toEqual(output);
   });
 
   it("should return empty FeatureCollection if Legs property is undefined", () => {

--- a/src/to-geojson/route-converter.ts
+++ b/src/to-geojson/route-converter.ts
@@ -275,11 +275,12 @@ function convertRouteToFeature(
   options?: { flattenProperties?: boolean },
 ): Feature<MultiLineString> {
   const processedLegs = route.Legs.map((leg) => leg.Geometry?.LineString).filter((leg) => leg);
-  const properties = options?.flattenProperties
-    ? flattenProperties(route.Summary, "")
-    : route.Summary
-    ? { Summary: { ...route.Summary, RouteBBox: undefined } }
-    : {};
+  let properties: Record<string, unknown> = {};
+  if (options?.flattenProperties) {
+    properties = flattenProperties(route.Summary, "");
+  } else if (route.Summary) {
+    properties.Summary = { ...route.Summary, RouteBBox: undefined };
+  }
   delete properties.RouteBBox;
   return {
     type: "Feature",

--- a/src/to-geojson/route-converter.ts
+++ b/src/to-geojson/route-converter.ts
@@ -3,7 +3,7 @@
 
 import { BBox, Feature, FeatureCollection, MultiLineString } from "geojson";
 import { CalculateRouteResponse } from "@aws-sdk/client-location";
-import { emptyFeatureCollection, toFeatureCollection } from "./utils";
+import { emptyFeatureCollection, toFeatureCollection, flattenProperties } from "./utils";
 
 /**
  * It converts a route to a GeoJSON FeatureCollection with a single MultiStringLine Feature, each LineString entry of
@@ -291,22 +291,4 @@ function convertRouteToFeature(
       coordinates: processedLegs,
     },
   };
-}
-
-/**
- * Optionally flatten the Amazon Location Service route summary object.
- *
- * @param obj Amazon Location Service route summary object.
- * @returns Flattened object.
- */
-function flattenProperties<T>(obj: T, prefix: string): Record<string, unknown> {
-  return Object.entries(obj as Record<string, unknown>).reduce((acc, [key, value]) => {
-    const newKey = prefix ? `${prefix}.${key}` : key;
-    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-      return { ...acc, ...flattenProperties(value, newKey) };
-    } else {
-      acc[newKey] = value;
-      return acc;
-    }
-  }, {});
 }

--- a/src/to-geojson/utils.ts
+++ b/src/to-geojson/utils.ts
@@ -20,6 +20,28 @@ export function toFeatureCollection<T extends Point | MultiLineString | Polygon>
   };
 }
 
+/**
+ * Optionally flatten the Amazon Location Service object.
+ *
+ * @param obj Amazon Location Service object.
+ * @returns Flattened object.
+ */
+export function flattenProperties(obj: unknown, prefix = ""): Record<string, unknown> {
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+    return {};
+  }
+  const result: Record<string, unknown> = {};
+  Object.entries(obj).forEach(([key, value]) => {
+    const newKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "object" && value !== null && !Array.isArray(value) && key !== "Geometry") {
+      Object.assign(result, flattenProperties(value, newKey));
+    } else {
+      result[newKey] = value;
+    }
+  });
+  return result;
+}
+
 export function emptyFeatureCollection<T extends Geometry>(): FeatureCollection<T> {
   return {
     type: "FeatureCollection",


### PR DESCRIPTION
- Added "flattenProperties" to flatten GeoJSON properties.

_Issue #, if available:_
https://github.com/aws-geospatial/amazon-location-utilities-datatypes-js/issues/33

_Description of changes:_
With the current implementation, when using MapLibre GL JS map.on('click'), the nested object becomes a string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
