### PR TITLE
Flatten simple geometry collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-# 1.1.0
+# Changes
+
+## 1.2.0
+
+### ✨ Features and improvements
+
+- Generate individual Polygons rather than GeometryCollections when isoline features contain single
+  geometries
+
+## 1.1.0
 
 ### ✨ Features and improvements
 

--- a/README.md
+++ b/README.md
@@ -266,11 +266,13 @@ const featureCollections = calculateRoutesResponseToFeatureCollections(response)
 
 ### calculateIsolinesResponseToFeatureCollection
 
-This converts a CalculateIsolineResponse from the standalone Routes SDK to a GeoJSON FeatureCollection which contains one Feature for each isoline
-in the response. Isolines can contain both polygons for isoline regions and lines for connectors between regions
-(such as ferry travel), so each Feature is a GeometryCollection that can contain a mix of Polygons and LineStrings.
-The `flattenProperties` option will flatten the nested response data into a flat properties list.
-This option is enabled by default, as it makes the data easier to use from within MapLibre expressions.
+This converts a CalculateIsolineResponse from the standalone Routes SDK to a GeoJSON
+FeatureCollection which contains one Feature for each isoline in the response. Isolines can contain
+both polygons for isoline regions and lines for connectors between regions (such as ferry travel),
+so each Feature contains either a GeometryCollection with a mix of Polygons and LineStrings or a
+single Polygon. The `flattenProperties` option will flatten the nested response data into a flat
+properties list. This option is enabled by default, as it makes the data easier to use from within
+MapLibre expressions.
 
 Any feature that is missing its geometry in the response or has invalid geometry will throw an Error().
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/amazon-location-utilities-datatypes",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/amazon-location-utilities-datatypes",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.683.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/amazon-location-utilities-datatypes",
   "description": "Amazon Location Utilities - Data Types for JavaScript",
   "license": "Apache-2.0",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "keywords": [],
   "author": {
     "name": "Amazon Web Services",

--- a/src/to-geojson/georoutes-converter.test.ts
+++ b/src/to-geojson/georoutes-converter.test.ts
@@ -1710,6 +1710,59 @@ describe("calculateIsolinesResponseToFeatureCollection", () => {
 
     expect(calculateIsolinesResponseToFeatureCollection(input, { flattenProperties: true })).toEqual(expectedResult);
   });
+
+  it("should return a Polygon (not a GeometryCollection) if no LineString is produced", () => {
+    const input: CalculateIsolinesResponse = {
+      IsolineGeometryFormat: "FlexiblePolyline",
+      PricingBucket: "bucket",
+      Isolines: [
+        {
+          Connections: [],
+          Geometries: [
+            {
+              PolylinePolygon: [
+                encodeFromLngLatArray([
+                  [0, 0],
+                  [10, 0],
+                  [10, 10],
+                  [0, 10],
+                  [0, 0],
+                ]),
+              ],
+            },
+          ],
+          TimeThreshold: 1000,
+        },
+      ],
+    };
+
+    const expectedResult: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: 0,
+          geometry: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [0, 0],
+                [10, 0],
+                [10, 10],
+                [0, 10],
+                [0, 0],
+              ],
+            ],
+          },
+          properties: {
+            TimeThreshold: 1000,
+          },
+        },
+      ],
+    };
+
+    expect(calculateIsolinesResponseToFeatureCollection(input, { flattenProperties: false })).toEqual(expectedResult);
+  });
 });
 
 describe("optimizeWaypointsResponseToFeatureCollection", () => {


### PR DESCRIPTION
_Description of changes:_

GeoJSONLint complains about these types of features:

> GeometryCollection with a single geometry should be avoided in favor of single part or a single object of multi-part type

This PR simplifies features containing GeometryCollections with single geometries by removing the intermediate GeometryCollection.

This simultaneously expands (`GeometryCollection | Polygon`) and narrows (`GeometryCollection<Polygon | LineString>`) the type of GeoJSON features created from isolines. We should consider the versioning implications of this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
