### PR TITLE
Add utilities to convert GPS trace file formats into SnapToRoads request

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,86 @@ const request = {
 };
 ```
 
+### featureCollectionToRoadSnapTracePointList
+
+Converts a GeoJSON FeatureCollection with Point Features to an array of RoadSnapTracePoint, so the result can be used to assemble the request to SnapToRoads API.
+
+```javascript
+const featureCollection = { ... };
+const request = {
+  Tracepoints: featureCollectionToRoadSnapTracePointList(featureCollection),
+};
+```
+
+## CSV to Amazon Location Data Types
+
+### csvStringToRoadSnapTracePointList
+
+Converts a CSV string to an array of RoadSnapTracePoint, so the result can be used to assemble the request to SnapToRoads API.
+The first line contains the attribute names, the subsequent lines the data in temporal order.
+
+```javascript
+const csvString = "....";
+const request = {
+  Tracepoints: csvStringToRoadSnapTracePointList(csvString),
+};
+```
+
+## GPX to Amazon Location Data Types
+
+### gpxToRoadSnapTracePointList
+
+Converts a GPX string to an array of RoadSnapTracePoint, so the result can be used to assemble the request to SnapToRoads API.
+
+```javascript
+const gpxString = "....";
+const request = {
+  Tracepoints: gpxToRoadSnapTracePointList(gpxString),
+};
+```
+
+## KML to Amazon Location Data Types
+
+### kmlStringToRoadSnapTracePointList
+
+Converts a KML string to an array of RoadSnapTracePoint, so the result can be used to assemble the request to SnapToRoads API.
+
+```javascript
+const kmlString = "....";
+const request = {
+  Tracepoints: kmlStringToRoadSnapTracePointList(kmlString),
+};
+```
+
+## NMEA to Amazon Location Data Types
+
+### nmeaStringToRoadSnapTracePointList
+
+Converts a NMEA string containing $GPRMC and/or $GPGGA records to an array of RoadSnapTracePoint, so the result can be
+used to assemble the request to SnapToRoads API.
+
+```javascript
+const nmeaString = "....";
+const request = {
+  Tracepoints: nmeaStringToRoadSnapTracePointList(nmeaString),
+};
+```
+
+## Flexible Polyline to Amazon Location Data Types
+
+### flexiblePolylineStringToRoadSnapTracePointList
+
+Converts a Flexible Polyline string to an array of RoadSnapTracePoint, so the result can be used to assemble the request
+to SnapToRoads API.
+
+```javascript
+const flexiblePolylineString = "....";
+const request = {
+  Tracepoints: flexiblePolylineStringToRoadSnapTracePointList(flexiblePolylineString),
+};
+__;
+```
+
 ## Amazon Location Data Types to GeoJSON
 
 ### devicePositionsToFeatureCollection

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,10 @@
         "@aws-sdk/client-geo-routes": "^3.683.0",
         "@aws-sdk/client-location": "^3.682.0",
         "@aws/polyline": "^0.1.0",
+        "@here/flexpolyline": "^0.1.0",
         "@turf/circle": "^6.5.0",
-        "@types/geojson": "^7946.0.14"
+        "@types/geojson": "^7946.0.14",
+        "csv-parse": "^5.5.6"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -2601,6 +2603,11 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@here/flexpolyline": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@here/flexpolyline/-/flexpolyline-0.1.0.tgz",
+      "integrity": "sha512-aiFWozFqTbeAG6S8AOH9QPF7UYjChE1ApV+0dK4kiWp+S2MIJXD/WzHZ9kwd8hDC8gHRAl/yVtJ50uVf26/ygQ=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -5035,6 +5042,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.6.tgz",
+      "integrity": "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A=="
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,10 @@
     "@aws-sdk/client-geo-routes": "^3.683.0",
     "@aws-sdk/client-location": "^3.682.0",
     "@aws/polyline": "^0.1.0",
+    "@here/flexpolyline": "^0.1.0",
     "@turf/circle": "^6.5.0",
-    "@types/geojson": "^7946.0.14"
+    "@types/geojson": "^7946.0.14",
+    "csv-parse": "^5.5.6"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/src/from-csv/index.ts
+++ b/src/from-csv/index.ts
@@ -1,2 +1,1 @@
-export * from "./geofence-converter";
 export * from "./tracepoints-converter";

--- a/src/from-csv/tracepoints-converter.test.ts
+++ b/src/from-csv/tracepoints-converter.test.ts
@@ -1,0 +1,23 @@
+import { csvStringToRoadSnapTracePointList } from "./tracepoints-converter";
+
+describe("csvToRoadSnapTracePointList", () => {
+  it("should convert csv string to RoadSnapTracePointList", () => {
+    const csvString = `latitude,longitude,speed_kmh,timestamp,heading
+      53.3737131,-1.4704939,12.5,2024-11-15T10:30:00Z,45
+      53.3742428,-1.4677477,15.8,2024-11-15T10:31:30Z,78`;
+    expect(csvStringToRoadSnapTracePointList(csvString)).toEqual([
+      {
+        Position: [-1.470494, 53.373713],
+        Speed: 12.5,
+        Timestamp: "2024-11-15T10:30:00Z",
+        Heading: 45,
+      },
+      {
+        Position: [-1.467748, 53.374243],
+        Speed: 15.8,
+        Timestamp: "2024-11-15T10:31:30Z",
+        Heading: 78,
+      },
+    ]);
+  });
+});

--- a/src/from-csv/tracepoints-converter.ts
+++ b/src/from-csv/tracepoints-converter.ts
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { parse } from "csv-parse/sync";
+import { RoadSnapTracePoint } from "@aws-sdk/client-geo-routes";
+
+/**
+ * It converts a CSV string to an array of RoadSnapTracePoint, so the result can be used to assemble the request to
+ * SnapToRoads API.
+ *
+ * @example Converting a CSV string
+ *
+ * Input:
+ *
+ * `latitude,longitude,speed_kmh,timestamp,heading 37.7749295,-122.4194239,18.3,2024-11-19T14:45:00Z,210
+ * 37.7750321,-122.4201567,22.6,2024-11-19T14:46:30Z,185`
+ *
+ * Output:
+ *
+ * ```json
+ * [
+ *   {
+ *     "Position": [-122.419424, 37.77493],
+ *     "Timestamp": "2024-11-19T14:45:00Z",
+ *     "Speed": 18.3,
+ *     "Heading": 210
+ *   },
+ *   {
+ *     "Position": [-122.420157, 37.775032],
+ *     "Timestamp": "2024-11-19T14:46:30Z",
+ *     "Speed": 22.6,
+ *     "Heading": 185
+ *   }
+ * ]
+ * ```
+ */
+export function csvStringToRoadSnapTracePointList(csvString: string) {
+  const records = parse(csvString, { columns: true, trim: true });
+
+  return records.map((row) => convertCSVToTracepoint(row));
+}
+
+function convertCSVToTracepoint(row): RoadSnapTracePoint | undefined {
+  const longitude = Math.round(parseFloat(row.longitude) * Math.pow(10, 6)) / Math.pow(10, 6);
+  const latitude = Math.round(parseFloat(row.latitude) * Math.pow(10, 6)) / Math.pow(10, 6);
+
+  const roadSnapTracePoint = { Position: [longitude, latitude] };
+  if (row.timestamp) {
+    roadSnapTracePoint["Timestamp"] = row.timestamp;
+  }
+  if (row.speed_kmh) {
+    const speedKMPH = row.speed_kmh;
+    roadSnapTracePoint["Speed"] = Math.round(speedKMPH * 100) / 100;
+  } else if (row.speed_mps) {
+    const speedKMPH = row.speed_mps * 3.6;
+    roadSnapTracePoint["Speed"] = Math.round(speedKMPH * 100) / 100;
+  } else if (row.speed_mph) {
+    const speedKMPH = row.speed_mph * 1.60934;
+    roadSnapTracePoint["Speed"] = Math.round(speedKMPH * 100) / 100;
+  }
+  if (row.heading) {
+    roadSnapTracePoint["Heading"] = parseFloat(row.heading);
+  }
+  return roadSnapTracePoint;
+}

--- a/src/from-flexible-polyline/index.ts
+++ b/src/from-flexible-polyline/index.ts
@@ -1,2 +1,1 @@
-export * from "./geofence-converter";
 export * from "./tracepoints-converter";

--- a/src/from-flexible-polyline/tracepoints-converter.test.ts
+++ b/src/from-flexible-polyline/tracepoints-converter.test.ts
@@ -1,0 +1,20 @@
+import { flexiblePolylineStringToRoadSnapTracePointList } from "./tracepoints-converter";
+
+describe("flexiblePolylineToRoadSnapTracePointList", () => {
+  it("should convert flexible polyline string to RoadSnapTracePointList", () => {
+    expect(flexiblePolylineStringToRoadSnapTracePointList("FP:BFoz5xJ67i1B1B7PzIhaxL7Y")).toEqual([
+      {
+        Position: [8.69821, 50.10228],
+      },
+      {
+        Position: [8.69567, 50.10201],
+      },
+      {
+        Position: [8.6915, 50.10063],
+      },
+      {
+        Position: [8.68752, 50.09878],
+      },
+    ]);
+  });
+});

--- a/src/from-flexible-polyline/tracepoints-converter.ts
+++ b/src/from-flexible-polyline/tracepoints-converter.ts
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { decode } from "@here/flexpolyline";
+import { RoadSnapTracePoint } from "@aws-sdk/client-geo-routes";
+
+/**
+ * It converts a Flexible Polyline string to an array of RoadSnapTracePoint, so the result can be used to assemble the
+ * request to SnapToRoads API.
+ *
+ * @example Converting a Flexible Polyline string
+ *
+ * Input:
+ *
+ * "FP:BFoz5xJ67i1B"
+ *
+ * Output:
+ *
+ * ```json
+ * [
+ *   { "Position": [-122.4194155, 37.77493] },
+ *   { "Position": [-122.4201567, 37.77503] },
+ *   { "Position": [-122.4209878, 37.77522] },
+ *   { "Position": [-122.4218390, 37.77540] }
+ * ]
+ * ```
+ */
+export function flexiblePolylineStringToRoadSnapTracePointList(fpString: string) {
+  if (fpString.startsWith("FP:")) {
+    const encodedString = fpString.slice(3);
+    const decodedString = decode(encodedString);
+
+    if (decodedString.polyline) {
+      return decodedString.polyline.map((coordinates) => convertCoordinatesToTracepoint(coordinates));
+    }
+  } else {
+    console.log("Invalid input: Flexible polyline string should start with 'FP:'");
+  }
+}
+
+function convertCoordinatesToTracepoint(coordinates): RoadSnapTracePoint {
+  const longitude = Math.round(coordinates[1] * Math.pow(10, 6)) / Math.pow(10, 6);
+  const latitude = Math.round(coordinates[0] * Math.pow(10, 6)) / Math.pow(10, 6);
+
+  return {
+    Position: [longitude, latitude],
+  };
+}

--- a/src/from-geojson/tracepoints-converter.test.ts
+++ b/src/from-geojson/tracepoints-converter.test.ts
@@ -1,0 +1,56 @@
+import { featureCollectionToRoadSnapTracePointList } from "./tracepoints-converter";
+
+describe("featureCollectionToRoadSnapTracePointList", () => {
+  it("should convert geojson to RoadSnapTracePointList", () => {
+    expect(
+      featureCollectionToRoadSnapTracePointList({
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {
+              provider: "gps",
+              timestamp_msec: 1566314007512,
+              accuracy: 18.224,
+              altitude: 213.361083984375,
+              heading: 177.3,
+              speed_mps: 0.65,
+            },
+            geometry: {
+              type: "Point",
+              coordinates: [8.53379056, 50.16352417],
+            },
+          },
+          {
+            type: "Feature",
+            properties: {
+              provider: "gps",
+              timestamp_msec: 1566314022526,
+              accuracy: 25.728,
+              altitude: 269.29180908203125,
+              heading: 69.4,
+              speed_mps: 5.45,
+            },
+            geometry: {
+              type: "Point",
+              coordinates: [8.5349375, 50.16338086],
+            },
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        Position: [8.53379056, 50.16352417],
+        Timestamp: "2019-08-20T15:13:27.512Z",
+        Speed: 2.34,
+        Heading: 177.3,
+      },
+      {
+        Position: [8.5349375, 50.16338086],
+        Timestamp: "2019-08-20T15:13:42.526Z",
+        Speed: 19.62,
+        Heading: 69.4,
+      },
+    ]);
+  });
+});

--- a/src/from-geojson/tracepoints-converter.ts
+++ b/src/from-geojson/tracepoints-converter.ts
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Feature, FeatureCollection, Point } from "geojson";
+import { RoadSnapTracePoint } from "@aws-sdk/client-geo-routes";
+
+/**
+ * It converts a FeatureCollection with Point Features to an array of RoadSnapTracePoint, so the result can be used to
+ * assemble the request to SnapToRoads API.
+ *
+ * @example Converting geojson tracepoints
+ *
+ * Input:
+ *
+ * ```json
+ * {
+ *   "type": "FeatureCollection",
+ *   "features": [
+ *     {
+ *       "type": "Feature",
+ *       "properties": {
+ *         "provider": "gps",
+ *         "timestamp_msec": 1700470800000,
+ *         "accuracy": 16.543,
+ *         "altitude": 42.187652587890625,
+ *         "heading": 189.6,
+ *         "speed_mps": 0.87
+ *       },
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [-122.41942389, 37.77492856]
+ *       }
+ *     },
+ *     {
+ *       "type": "Feature",
+ *       "properties": {
+ *         "provider": "gps",
+ *         "timestamp_msec": 1700470815000,
+ *         "accuracy": 23.891,
+ *         "altitude": 45.63214111328125,
+ *         "heading": 201.3,
+ *         "speed_mps": 4.12
+ *       },
+ *       "geometry": {
+ *         "type": "Point",
+ *         "coordinates": [-122.42015672, 37.77503214]
+ *       }
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * Output:
+ *
+ * ```json
+ * [
+ *   {
+ *     "Position": [-122.41942389, 37.77492856],
+ *     "Timestamp": "2023-11-20T09:00:00.000Z",
+ *     "Speed": 3.13,
+ *     "Heading": 189.6
+ *   },
+ *   {
+ *     "Position": [-122.42015672, 37.77503214],
+ *     "Timestamp": "2023-11-20T09:00:15.000Z",
+ *     "Speed": 14.83,
+ *     "Heading": 201.3
+ *   }
+ * ]
+ * ```
+ */
+export function featureCollectionToRoadSnapTracePointList(featureCollection: FeatureCollection<Point>) {
+  return featureCollection.features.map((feature) => convertFeatureToTracepoint(feature));
+}
+
+function convertFeatureToTracepoint(feature: Feature<Point>): RoadSnapTracePoint | undefined {
+  if (feature) {
+    const roadSnapTracePoint = {
+      Position: feature.geometry.coordinates,
+    };
+
+    if (feature.properties.timestamp_msec) {
+      const timestamp = new Date(feature.properties.timestamp_msec);
+      roadSnapTracePoint["Timestamp"] = timestamp.toISOString();
+    }
+
+    if (feature.properties.speed_mps) {
+      const speedKMPH = feature.properties.speed_mps * 3.6;
+      roadSnapTracePoint["Speed"] = Math.round(speedKMPH * 100) / 100;
+    }
+
+    if (feature.properties.heading) {
+      roadSnapTracePoint["Heading"] = parseFloat(feature.properties.heading);
+    }
+
+    return roadSnapTracePoint;
+  }
+}

--- a/src/from-gpx/index.ts
+++ b/src/from-gpx/index.ts
@@ -1,2 +1,1 @@
-export * from "./geofence-converter";
 export * from "./tracepoints-converter";

--- a/src/from-gpx/tracepoints-converter.test.ts
+++ b/src/from-gpx/tracepoints-converter.test.ts
@@ -1,0 +1,35 @@
+import { gpxToRoadSnapTracePointList } from "./tracepoints-converter";
+
+describe("gpxToRoadSnapTracePointList", () => {
+  it("should convert gpx string to RoadSnapTracePointList", () => {
+    const gpxString = `<?xml version="1.0" encoding="UTF-8"?>
+      <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gte="http://www.gpstrackeditor.com/xmlschemas/General/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" targetNamespace="http://www.topografix.com/GPX/1/1" elementFormDefault="qualified" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+        <metadata>
+            <name>sample_rome.gpx</name>
+            <desc>Sample data collected in Rome: showing finding main roads, ignored waypoints, illegal one ways( near #45, #81), gate traversal(near #72), passing  no-through-traffic zone (near #79)</desc>
+        </metadata>
+        <trk>
+            <name>Rome</name>
+            <trkseg>
+                <trkpt lat="41.899689" lon="12.419255"> <extensions><speed>10</speed></extensions> <time>2013-07-15T10:24:52Z</time>
+                </trkpt>
+                <trkpt lat="41.900891" lon="12.420505"> <extensions><speed>10</speed></extensions> <time>2013-07-15T10:24:52Z</time>
+                </trkpt>
+            </trkseg>
+        </trk>
+      </gpx>`;
+
+    expect(gpxToRoadSnapTracePointList(gpxString)).toEqual([
+      {
+        Position: [12.419255, 41.899689],
+        Speed: 36,
+        Timestamp: "2013-07-15T10:24:52Z",
+      },
+      {
+        Position: [12.420505, 41.900891],
+        Speed: 36,
+        Timestamp: "2013-07-15T10:24:52Z",
+      },
+    ]);
+  });
+});

--- a/src/from-gpx/tracepoints-converter.ts
+++ b/src/from-gpx/tracepoints-converter.ts
@@ -1,0 +1,103 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as fastXmlParser from "fast-xml-parser";
+import { RoadSnapTracePoint } from "@aws-sdk/client-geo-routes";
+
+/**
+ * It converts a GPX string to an array of RoadSnapTracePoint, so the result can be used to assemble the request to
+ * SnapToRoads API.
+ *
+ * @example Converting a GPX string
+ *
+ * Input:
+ *
+ * ```xml
+ * <?xml version="1.0" encoding="UTF-8"?>
+ * <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gte="http://www.gpstrackeditor.com/xmlschemas/General/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" targetNamespace="http://www.topografix.com/GPX/1/1" elementFormDefault="qualified" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+ *   <metadata>
+ *     <name>sample_san_francisco.gpx</name>
+ *     <desc>Sample data collected in San Francisco: demonstrating urban navigation, including steep hills and busy intersections</desc>
+ *   </metadata>
+ *   <trk>
+ *     <name>San Francisco</name>
+ *     <trkseg>
+ *       <trkpt lat="37.774930" lon="-122.419424">
+ *         <extensions>
+ *           <speed>5.08</speed>
+ *         </extensions>
+ *         <time>2024-11-19T14:45:00Z</time>
+ *       </trkpt>
+ *       <trkpt lat="37.775032" lon="-122.420157">
+ *         <extensions>
+ *           <speed>6.28</speed>
+ *         </extensions>
+ *         <time>2024-11-19T14:46:30Z</time>
+ *       </trkpt>
+ *     </trkseg>
+ *   </trk>
+ * </gpx>
+ * ```
+ *
+ * Output:
+ *
+ * ```json
+ * [
+ *   {
+ *     "Position": [-122.419424, 37.77493],
+ *     "Speed": 18.29,
+ *     "Timestamp": "2024-11-19T14:45:00Z"
+ *   },
+ *   {
+ *     "Position": [-122.420157, 37.775032],
+ *     "Speed": 22.61,
+ *     "Timestamp": "2024-11-19T14:46:30Z"
+ *   }
+ * ]
+ * ```
+ */
+export function gpxToRoadSnapTracePointList(content) {
+  const options = {
+    attributeNamePrefix: "",
+    attrNodeName: "attr",
+    textNodeName: "#text",
+    ignoreAttributes: false,
+    ignoreNamespace: false,
+    allowBooleanAttributes: false,
+    parseNodeValue: true,
+    parseAttributeValue: false,
+    trimValues: true,
+    cdataTagName: "__cdata",
+    cdataPositionChar: "\\c",
+    parseTrueNumberOnly: false,
+    numParseOptions: {
+      hex: true,
+      leadingZeros: true,
+      decimalSeparator: ".",
+      parseType: "number",
+    },
+    arrayMode: "strict",
+  };
+  const xmlParser = new fastXmlParser.XMLParser(options);
+  const jsonObj = xmlParser.parse(content, options);
+  const trackPoints = jsonObj.gpx.trk.trkseg.trkpt;
+
+  return trackPoints.map((trackPoint) => convertGPXToTracepoint(trackPoint));
+}
+
+function convertGPXToTracepoint(trackPoint): RoadSnapTracePoint | undefined {
+  if (trackPoint) {
+    const longitude = Math.round(parseFloat(trackPoint.lon) * Math.pow(10, 6)) / Math.pow(10, 6);
+    const latitude = Math.round(parseFloat(trackPoint.lat) * Math.pow(10, 6)) / Math.pow(10, 6);
+
+    const roadSnapTracePoint = { Position: [longitude, latitude] };
+    if (trackPoint.extensions.speed) {
+      const speedKMPH = trackPoint.extensions.speed * 3.6;
+      roadSnapTracePoint["Speed"] = Math.round(speedKMPH * 100) / 100;
+    }
+    if (trackPoint.time) {
+      roadSnapTracePoint["Timestamp"] = trackPoint.time;
+    }
+    return roadSnapTracePoint;
+  }
+}

--- a/src/from-kml/index.ts
+++ b/src/from-kml/index.ts
@@ -1,2 +1,1 @@
-export * from "./geofence-converter";
 export * from "./tracepoints-converter";

--- a/src/from-kml/tracepoints-converter.test.ts
+++ b/src/from-kml/tracepoints-converter.test.ts
@@ -1,0 +1,57 @@
+import { kmlStringToRoadSnapTracePointList } from "./tracepoints-converter";
+
+describe("kmlStringToRoadSnapTracePointList", () => {
+  it("should convert kml string with point placemarks to RoadSnapTracePointList", () => {
+    const kmlString = `<?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 ogckml22.xsd">
+        <Document><name>Sample Frankfurt KML Trace</name> 
+          <Placemark><Point><coordinates>8.64914,50.20346,0.0 </coordinates></Point></Placemark>
+          <Placemark><Point><coordinates>8.64861,50.20319,0.0 </coordinates></Point></Placemark>
+        </Document>
+      </kml>`;
+
+    expect(kmlStringToRoadSnapTracePointList(kmlString)).toEqual([
+      {
+        Position: [8.64914, 50.20346],
+      },
+      {
+        Position: [8.64861, 50.20319],
+      },
+    ]);
+  });
+  it("should convert kml string with linestring placemarks to RoadSnapTracePointList", () => {
+    const kmlString = `<?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <name>Sample LineString Path</name>
+          <description>A simple path with three points</description>
+          <Placemark>
+            <name>Path Example</name>
+            <description>This is a sample path</description>
+            <LineString>
+              <extrude>1</extrude>
+              <tessellate>1</tessellate>
+              <altitudeMode>relativeToGround</altitudeMode>
+              <coordinates>
+                -122.364383,37.824664,0
+                -122.364152,37.824322,0
+                -122.363932,37.824240,0
+              </coordinates>
+            </LineString>
+          </Placemark>
+        </Document>
+      </kml>`;
+
+    expect(kmlStringToRoadSnapTracePointList(kmlString)).toEqual([
+      {
+        Position: [-122.364383, 37.824664],
+      },
+      {
+        Position: [-122.364152, 37.824322],
+      },
+      {
+        Position: [-122.363932, 37.82424],
+      },
+    ]);
+  });
+});

--- a/src/from-kml/tracepoints-converter.ts
+++ b/src/from-kml/tracepoints-converter.ts
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as fastXmlParser from "fast-xml-parser";
+
+/**
+ * It converts a KML string to an array of RoadSnapTracePoint, so the result can be used to assemble the request to
+ * SnapToRoads API.
+ *
+ * @example Converting a KML string
+ *
+ * Input:
+ *
+ * ```xml
+ * <?xml version="1.0" encoding="UTF-8"?>
+ * <kml xmlns="http://www.opengis.net/kml/2.2">
+ *   <Document>
+ *     <name>San Francisco Path</name>
+ *     <description>A simple path with two points in San Francisco</description>
+ *     <Placemark>
+ *       <name>SF Downtown Route</name>
+ *       <description>A short route in downtown San Francisco</description>
+ *       <LineString>
+ *         <extrude>1</extrude>
+ *         <tessellate>1</tessellate>
+ *         <altitudeMode>relativeToGround</altitudeMode>
+ *         <coordinates>
+ *           -122.419424,37.774930,0
+ *           -122.420157,37.775032,0
+ *         </coordinates>
+ *       </LineString>
+ *     </Placemark>
+ *   </Document>
+ * </kml>
+ * ```
+ *
+ * Output:
+ *
+ * ```json
+ * [
+ *   {
+ *     "Position": [12.419255, 41.899689],
+ *     "Speed": 36,
+ *     "Timestamp": "2013-07-15T10:24:52Z"
+ *   },
+ *   {
+ *     "Position": [12.420505, 41.900891],
+ *     "Speed": 36,
+ *     "Timestamp": "2013-07-15T10:24:52Z"
+ *   }
+ * ]
+ * ```
+ */
+export function kmlStringToRoadSnapTracePointList(kmlString: string) {
+  const xmlParser = new fastXmlParser.XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_",
+  });
+
+  const result = xmlParser.parse(kmlString);
+  const placemarks = Array.isArray(result.kml.Document.Placemark)
+    ? result.kml.Document.Placemark
+    : [result.kml.Document.Placemark];
+
+  return placemarks.flatMap((placemark) => {
+    if (placemark.Point) {
+      const [lon, lat] = placemark.Point.coordinates.split(",").map(Number);
+      return [
+        {
+          Position: roundCoordinates(lon, lat),
+        },
+      ];
+    } else if (placemark.LineString) {
+      const coordinates = placemark.LineString.coordinates.trim().split(/\s+/);
+      return coordinates.map((coord) => {
+        const [lon, lat] = coord.split(",").map(Number);
+        return {
+          Position: roundCoordinates(lon, lat),
+        };
+      });
+    } else {
+      console.log("Invalid input: unrecognized placemark format'");
+    }
+  });
+}
+
+function roundCoordinates(lon, lat): [number, number] {
+  return [
+    Math.round(parseFloat(lon) * Math.pow(10, 6)) / Math.pow(10, 6),
+    Math.round(parseFloat(lat) * Math.pow(10, 6)) / Math.pow(10, 6),
+  ];
+}

--- a/src/from-nmea/index.ts
+++ b/src/from-nmea/index.ts
@@ -1,2 +1,1 @@
-export * from "./geofence-converter";
 export * from "./tracepoints-converter";

--- a/src/from-nmea/tracepoints-converter.test.ts
+++ b/src/from-nmea/tracepoints-converter.test.ts
@@ -1,0 +1,19 @@
+import { nmeaStringToRoadSnapTracePointList } from "./tracepoints-converter";
+
+describe("nmeaStringToRoadSnapTracePointList", () => {
+  it("should convert kml string to RoadSnapTracePointList", () => {
+    const nmeaString = `$GPGGA,123519,4916.45,N,12311.12,W,1,08,0.9,545.4,M,46.9,M,,*47
+      $GPRMC,225446,A,3751.65,S,14507.36,E,022.4,084.4,191194,003.1,W*6A`;
+
+    expect(nmeaStringToRoadSnapTracePointList(nmeaString)).toEqual([
+      {
+        Position: [-17.185333, 49.274167],
+      },
+      {
+        Position: [22.456, -37.860833],
+        Speed: 41.48,
+        Timestamp: "1994-11-19T22:54:46.000Z",
+      },
+    ]);
+  });
+});

--- a/src/from-nmea/tracepoints-converter.ts
+++ b/src/from-nmea/tracepoints-converter.ts
@@ -1,0 +1,166 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RoadSnapTracePoint } from "@aws-sdk/client-geo-routes";
+
+const PIVOT_YEAR = 80;
+
+/**
+ * It converts a NMEA string containing $GPRMC and/or $GPGGA records to an array of RoadSnapTracePoint, so the result
+ * can be used to assemble the request to SnapToRoads API.
+ *
+ * @example Converting a NMEA string
+ *
+ * Input:
+ *
+ * `$GPGGA,144500,3746.4945,N,12225.1642,W,1,08,1.2,25.4,M,-28.9,M,,*6E
+ * $GPRMC,144630,A,3746.5019,N,12225.2094,W,5.1,185.0,191124,013.2,E*6A`
+ *
+ * Output:
+ *
+ * ```json
+ * [
+ *   {
+ *     "Position": [-15.752737, 37.774908]
+ *   },
+ *   {
+ *     "Position": [-15.75349, 37.775032],
+ *     "Timestamp": "2024-11-19T14:46:30.000Z",
+ *     "Speed": 9.45
+ *   }
+ * ]
+ * ```
+ */
+export function nmeaStringToRoadSnapTracePointList(nmeaString: string) {
+  const records = nmeaString
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+
+  return records
+    .map((record) => convertNMEAToTracepoint(record))
+    .filter((data): data is RoadSnapTracePoint => data !== null);
+}
+
+function convertNMEAToTracepoint(record: string): RoadSnapTracePoint | null {
+  if (record.startsWith("$GPRMC")) {
+    return parseGPRMC(record);
+  } else if (record.startsWith("$GPGGA")) {
+    return parseGPGGA(record);
+  } else {
+    console.error("Unsupported NMEA record: ", record.split(",")[0]);
+    return null;
+  }
+}
+
+function parseGPRMC(record: string): RoadSnapTracePoint | null {
+  const parts = record.split(",");
+
+  if (parts.length < 12) {
+    console.error("Invalid GPRMC record: not enough fields");
+    return null;
+  }
+
+  const [
+    ,
+    // skipping identifier
+    timeStr, // skipping status
+    ,
+    latitudeStr,
+    latitudeDir,
+    longitudeStr,
+    longitudeDir,
+    speedStr, // skipping track
+    ,
+    dateStr, // skipping magnetic variation // skipping variation direction
+    ,
+    ,
+  ] = parts;
+
+  const latitude = parseCoordinate(latitudeStr, latitudeDir);
+  const longitude = parseCoordinate(longitudeStr, longitudeDir);
+
+  const roadSnapTracePoint = { Position: [longitude, latitude] };
+
+  if (timeStr && dateStr) {
+    const timestamp = convertToISOTime(dateStr, timeStr);
+    roadSnapTracePoint["Timestamp"] = timestamp;
+  }
+  if (speedStr) {
+    const speedKMPH = parseFloat(speedStr) * 1.852; // convert knots to km/h
+    roadSnapTracePoint["Speed"] = Math.round(speedKMPH * 100) / 100;
+  }
+
+  return roadSnapTracePoint;
+}
+
+function parseGPGGA(record: string): RoadSnapTracePoint | null {
+  const parts = record.split(",");
+
+  if (parts.length < 14) {
+    console.error("Invalid GPGGA record: not enough fields");
+    return null;
+  }
+
+  const [
+    ,
+    ,
+    // skipping identifier
+    // skipping time. GPGGA doesn't contain date information, so we cannot construct the timestamp.
+    latitudeStr,
+    latitudeDir,
+    longitudeStr,
+    longitudeDir, // skipping fix quality // skipping number of satellites // skipping HDOP // skipping altitude // skipping altitude unit // skipping geoid height // skipping geoid height unit // skipping time since last DGPS update // skipping DGPS station ID
+    ,
+    ,
+    ,
+    ,
+    ,
+    ,
+    ,
+    ,
+    ,
+  ] = parts;
+
+  const latitude = parseCoordinate(latitudeStr, latitudeDir);
+  const longitude = parseCoordinate(longitudeStr, longitudeDir);
+
+  return { Position: [longitude, latitude] };
+}
+
+function parseCoordinate(coord: string, direction: string): number {
+  if (!coord || !direction) return 0;
+  const degrees = parseFloat(coord.slice(0, 2));
+  const minutes = parseFloat(coord.slice(2)) / 60;
+  let result = degrees + minutes;
+  if (direction === "S" || direction === "W") {
+    result = -result;
+  }
+
+  return Math.round(result * Math.pow(10, 6)) / Math.pow(10, 6);
+}
+function convertToISOTime(dateStr: string, timeStr: string): string {
+  if (dateStr.length !== 6 || timeStr.length < 6) {
+    throw new Error("Invalid date or time format");
+  }
+
+  // Extract components from the date string
+  const day = dateStr.slice(0, 2);
+  const month = dateStr.slice(2, 4);
+  const year = dateStr.slice(4, 6);
+
+  // Extract components from the time string
+  const hours = timeStr.slice(0, 2);
+  const minutes = timeStr.slice(2, 4);
+  const seconds = timeStr.slice(4, 6);
+  const milliseconds = timeStr.length > 6 ? timeStr.slice(7) : "000";
+
+  // Use a fixed windowing approach to interpret two-digit years:
+  // Years 00-79 are interpreted as 2000-2079
+  // Years 80-99 are interpreted as 1980-1999
+  const fullYear = parseInt(year) < PIVOT_YEAR ? `20${year}` : `19${year}`;
+
+  const isoString = `${fullYear}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds}Z`;
+
+  return isoString;
+}


### PR DESCRIPTION
Description of changes: 

This PR adds utilities to convert different GPS trace file formats into SnapToRoads request JSON. 

The following are the supported trace file formats as described in [HERE's documentation](https://www.here.com/docs/bundle/route-matching-api-developer-guide/page/topics/trace-files.html#trace-file-formats):
- Geojson
- GPX 
- KML 
- CSV 
- NMEA
- [Flexible Polyline](https://github.com/heremaps/flexible-polyline) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
