### PR TITLE
feat: add npm-audit-check workflow with hard coded vulnerability

### DIFF
--- a/.github/workflows/npm-audit-check.yml
+++ b/.github/workflows/npm-audit-check.yml
@@ -1,0 +1,13 @@
+name: NPM Audit Check
+on:
+  schedule:
+    - cron: "30 16 * * 5" # Every Friday 11:30 CT (16:30 UTC during CDT, 10:30 CT during CST)
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+jobs:
+  run:
+    uses: aws-geospatial/github-workflows-for-amazon-location/.github/workflows/npm-audit-check.yml@main
+    with:
+      package-name: "minimist@1.2.5" # TEMP: validate vuln detection path. Revert in follow-up commit.


### PR DESCRIPTION
Hardcodes package-name to minimist@1.2.5 in this commit to validate the vuln-detection and issue-creation path end-to-end. Follow-up commit reverts to auditing the published package.

