### PR TITLE
fix: use request as npm-audit test package

### DIFF
--- a/.github/workflows/npm-audit-check.yml
+++ b/.github/workflows/npm-audit-check.yml
@@ -10,4 +10,4 @@ jobs:
   run:
     uses: aws-geospatial/github-workflows-for-amazon-location/.github/workflows/npm-audit-check.yml@main
     with:
-      package-name: "minimist@1.2.5" # TEMP: validate vuln detection path. Revert in follow-up commit.
+      package-name: "request" # TEMP: validate vuln detection path. Revert in follow-up commit.


### PR DESCRIPTION
## Summary

Swaps the `package-name` override from `minimist@1.2.5` to `request` so manual workflow dispatches can validate the vuln detection path end-to-end.

## Why

The reusable workflow treats `package-name` as a bare name and appends the resolved version itself (`$NAME@$VERSION`). Passing `minimist@1.2.5` produced `minimist@1.2.5@1.2.5`, which is an invalid npm spec — the audit step failed with exit 1 and no issue was filed.

`request` is deprecated (last published 2020) with 5 vulnerabilities in transitive deps (`form-data`, `qs`, `tough-cookie`, `uuid`) at latest. No version pin needed, no risk of the test silently passing when upstream patches land.

## Expected result on dispatch

- Audit runs against `request@2.88.2`
- 5 vulnerabilities reported (2 critical, 3 moderate)
- New issue filed with title `[npm-audit] request — vulnerabilities found`

Follow-up PR will revert `package-name` to empty (audit this repo's own package) once validation is complete.