### PR TITLE
chore: remove temporary package-name override

### DIFF
--- a/.github/workflows/npm-audit-check.yml
+++ b/.github/workflows/npm-audit-check.yml
@@ -9,5 +9,3 @@ permissions:
 jobs:
   run:
     uses: aws-geospatial/github-workflows-for-amazon-location/.github/workflows/npm-audit-check.yml@main
-    with:
-      package-name: "request" # TEMP: validate vuln detection path. Revert in follow-up commit.


### PR DESCRIPTION
Validation complete — vuln detection path confirmed working against 'request' (5 vulns, issue filed). Reverting to default behavior so the workflow audits this repo's own published package.

Results
- https://github.com/aws-geospatial/amazon-location-utilities-datatypes-js/actions/runs/25233829018
- https://github.com/aws-geospatial/amazon-location-utilities-datatypes-js/issues/76