### PR TITLE
Update build workflow to trigger after Auto Security Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_run:
+    workflows: ["Auto Security Release"]
+    types: [completed]
 
 concurrency:
   # cancel jobs on PRs only
@@ -17,9 +20,14 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    if: >
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
_Issue #, if available:_ N/A

_Description of changes:_ PR cut by workflows did not trigger build check. This change attempts to fix that and will be reverted if it doesn't.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
