### PR TITLE
fix: report build status back to the PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     permissions:
       contents: read
+      statuses: write
     runs-on: ubuntu-latest
     if: >
       github.event_name != 'workflow_run' ||
@@ -27,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -44,3 +45,18 @@ jobs:
         run: npm run build
       - name: Pack
         run: npm pack
+
+      - name: Report status to PR
+        if: always() && github.event_name == 'workflow_run'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.workflow_run.head_sha }}',
+              state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
+              context: 'build',
+              description: 'Build triggered by Auto Security Release',
+              target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Once the build step is triggered by the PR generated by the Auto Security Release workflow, it needs to report back to the PR to unblock. This change adds that script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
