### PR TITLE
Relase new version 1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changes
 
+## 1.2.4
+
+### 🐛 Bug Fixes
+
+- Add null safety checks and improve type safety
+- Fix build status reporting back to PRs
+- Fix scheduled workflow with default force value
+
+### ✨ Features and improvements
+
+- Bumped @babel/plugin-transform-modules-systemjs from 7.25.9 to 7.29.4
+- Bumped fast-xml-builder from 1.1.5 to 1.2.0
+- Bumped fast-xml-parser and @aws-sdk/xml-builder
+- Bumped brace-expansion from 1.1.12 to 1.1.13
+- Bumped yaml and lint-staged
+- Bumped picomatch from 2.3.1 to 2.3.2
+- Bumped flatted from 3.3.1 to 3.4.2
+- Bumped minimatch from 3.1.2 to 3.1.5
+- Bumped rollup from 3.29.5 to 3.30.0
+- Bumped ajv from 6.12.6 to 6.14.0
+- Added npm-audit-check workflow
+- Updated build workflow to use node 20
+
 ## 1.2.3
 
 ### ✨ Features and improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/amazon-location-utilities-datatypes",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/amazon-location-utilities-datatypes",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.683.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/amazon-location-utilities-datatypes",
   "description": "Amazon Location Utilities - Data Types for JavaScript",
   "license": "Apache-2.0",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "keywords": [],
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
## Summary

  This patch release (v1.2.4) includes important bug fixes, security updates, and dependency upgrades accumulated since v1.2.3.

  ## 🐛 Bug Fixes

  - Add null safety checks and improve type safety (#85)
  - Fix build status reporting back to PRs (#83)
  - Fix scheduled workflow with default force value (#80)

  ## ✨ Features and Improvements

  ### Security & Dependency Updates
  - Bumped @babel/plugin-transform-modules-systemjs from 7.25.9 to 7.29.4 (#87)
  - Bumped fast-xml-builder from 1.1.5 to 1.2.0 (#86)
  - Bumped fast-xml-parser and @aws-sdk/xml-builder (multiple updates)
  - Bumped brace-expansion from 1.1.12 to 1.1.13 (#70)
  - Bumped yaml and lint-staged (#69)
  - Bumped picomatch from 2.3.1 to 2.3.2 (#68)
  - Bumped flatted from 3.3.1 to 3.4.2 (#66)
  - Bumped minimatch from 3.1.2 to 3.1.5 (#63)
  - Bumped rollup from 3.29.5 to 3.30.0 (#61)
  - Bumped ajv from 6.12.6 to 6.14.0 (#59)

  ### CI/CD Improvements
  - Added npm-audit-check workflow (#74)
  - Updated build workflow to use Node 20 (#72)
  - Enhanced PR release workflow integration

  ## Testing

  - ✅ All existing tests pass
  - ✅ Build completes successfully
  - ✅ Dependencies audit clean