### PR TITLE
Use GitHub App token instead of GITHUB_TOKEN for auto-security-release

### DIFF
--- a/.github/workflows/auto-security-release.yml
+++ b/.github/workflows/auto-security-release.yml
@@ -19,3 +19,6 @@ jobs:
     uses: aws-geospatial/github-workflows-for-amazon-location/.github/workflows/auto-security-release.yml@main
     with:
       force: ${{ inputs.force || false }}
+    secrets:
+      APP_ID: ${{ secrets.AUTO_RELEASE_BOT_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.AUTO_RELEASE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
GitHub tokens can't be used to auto trigger downstream workflows so switching to a github app created for this

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
