### PR TITLE
Remove trigger which forced a build after auto sec release workflow success

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_run:
-    workflows: ["Auto Security Release"]
-    types: [completed]
 
 concurrency:
   # cancel jobs on PRs only
@@ -19,16 +16,10 @@ jobs:
   build:
     permissions:
       contents: read
-      statuses: write
     runs-on: ubuntu-latest
-    if: >
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -45,18 +36,3 @@ jobs:
         run: npm run build
       - name: Pack
         run: npm pack
-
-      - name: Report status to PR
-        if: always() && github.event_name == 'workflow_run'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ github.event.workflow_run.head_sha }}',
-              state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
-              context: 'build',
-              description: 'Build triggered by Auto Security Release',
-              target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            });


### PR DESCRIPTION

_Issue #, if available:_

_Description of changes:_
As we're using a GitHub app token to trigger workflows, we don't need to force trigger this as it's automatically being run

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
