### PR TITLE
Add workflow which runs every day to retry dependabot issues which failed to create PRs

### DIFF
--- a/.github/workflows/dependabot-retry.yml
+++ b/.github/workflows/dependabot-retry.yml
@@ -1,0 +1,17 @@
+name: Dependabot Auto Retry
+permissions:
+  security-events: write
+  pull-requests: read
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+jobs:
+  run:
+    permissions:
+      security-events: write
+      pull-requests: read
+    uses: aws-geospatial/github-workflows-for-amazon-location/.github/workflows/dependabot-retry.yml@main
+    secrets:
+      APP_ID: ${{ secrets.AUTO_RELEASE_BOT_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.AUTO_RELEASE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

 Pass GitHub App token secrets to the dependabot-retry common workflow. The common workflow was updated to use a
  GitHub App token instead of GITHUB_TOKEN for elevated permissions needed to trigger Dependabot alert reruns.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
